### PR TITLE
Add new driver specific configurations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -25,13 +25,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	replicationv1alpha1 "github.com/kube-storage/volume-replication-operator/api/v1alpha1"
+	"github.com/kube-storage/volume-replication-operator/pkg/config"
 )
 
 // VolumeReplicationReconciler reconciles a VolumeReplication object
 type VolumeReplicationReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log          logr.Logger
+	Scheme       *runtime.Scheme
+	DriverConfig *config.DriverConfig
 }
 
 // +kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumereplications,verbs=get;list;watch;create;update;patch;delete
@@ -56,7 +58,8 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *VolumeReplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *VolumeReplicationReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.DriverConfig) error {
+	r.DriverConfig = cfg
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&replicationv1alpha1.VolumeReplication{}).
 		Complete(r)

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	flag.StringVar(&cfg.DriverName, "driver-name", "", "The CSI driver name.")
 	flag.StringVar(&cfg.DriverEndpoint, "csi-address", "/run/csi/socket", "Address of the CSI driver socket.")
 	flag.DurationVar(&cfg.RPCTimeout, "rpc-timeout", defaultTimeout, "The timeout for RPCs to the CSI driver.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":9998", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"errors"
+	"time"
+)
+
+// DriverConfig holds the CSI driver configuration.
+type DriverConfig struct {
+	// DriverEndpoint represents the gRPC endpoint for CSI driver.
+	DriverEndpoint string
+	// DriverName is the name of CSI Driver.
+	DriverName string
+	// RPCTimeout for RPCs to the CSI driver.
+	RPCTimeout time.Duration
+}
+
+// NewDriverConfig returns the newly initialized DriverConfig.
+func NewDriverConfig() *DriverConfig {
+	return &DriverConfig{}
+}
+
+// Validate operation configrations.
+func (cfg *DriverConfig) Validate() error {
+	// check driver name is set
+	if cfg.DriverName == "" {
+		return errors.New("driverName is empty")
+	}
+	return nil
+}


### PR DESCRIPTION
This PR does below changes

* Add New DriverConfig structure which holds the required information to establish the connection with CSI driver
* dynamic generation of  leader election ID 
* Add leader election Namespace
* Change health-probe-bind-address to `9998`
* Disable Metrics by default

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>