### PR TITLE
Implement DemoteVolume RPC calls.

### DIFF
--- a/controllers/parameters.go
+++ b/controllers/parameters.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"strings"
+)
+
+const (
+	// Replication Parameters prefixed with replicationParameterPrefix are not passed through
+	// to the driver on RPC calls. Instead these are the parameters used by the
+	// operator to get the required object from kubernetes and pass it to the
+	// Driver.
+	replicationParameterPrefix = "replication.storage.openshift.io/"
+
+	prefixedReplicationSecretNameKey      = replicationParameterPrefix + "replication-secret-name"      // name key for secret
+	prefixedReplicationSecretNamespaceKey = replicationParameterPrefix + "replication-secret-namespace" // namespace key secret
+)
+
+// filterPrefixedParameters removes all the reserved keys from the
+// replicationclass which are matching the prefix.
+func filterPrefixedParameters(prefix string, param map[string]string) map[string]string {
+	newParam := map[string]string{}
+	for k, v := range param {
+		if !strings.HasPrefix(k, prefix) {
+			newParam[k] = v
+		}
+	}
+	return newParam
+}

--- a/controllers/parameters.go
+++ b/controllers/parameters.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -41,4 +43,27 @@ func filterPrefixedParameters(prefix string, param map[string]string) map[string
 		}
 	}
 	return newParam
+}
+
+// validatePrefixParameters checks for unknown reserved keys in parameters and
+// empty values for reserved keys.
+func validatePrefixedParameters(param map[string]string) error {
+	for k, v := range param {
+		if strings.HasPrefix(k, replicationParameterPrefix) {
+			switch k {
+			case prefixedReplicationSecretNameKey:
+				if v == "" {
+					return errors.New("secret name cannot be empty")
+				}
+			case prefixedReplicationSecretNamespaceKey:
+				if v == "" {
+					return errors.New("secret namespace cannot be empty")
+				}
+			// keep adding known prefixes to this list.
+			default:
+				return fmt.Errorf("found unknown parameter key %q with reserved prefix %s", k, replicationParameterPrefix)
+			}
+		}
+	}
+	return nil
 }

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// getSecret retrives the secrets based on name and namespace input
+func (r *VolumeReplicationReconciler) getSecret(name, namespace string) (map[string]string, error) {
+	namespacedName := types.NamespacedName{Name: name, Namespace: namespace}
+	secret := &corev1.Secret{}
+	err := r.Client.Get(context.TODO(), namespacedName, secret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.Log.Error(err, "Secret not found", "Secret Name", name, "Secret Namespace", namespace)
+		}
+		r.Log.Error(err, "error getting secret", "Secret Name", name, "Secret Namespace", namespace)
+		return nil, err
+	}
+	return secret.StringData, nil
+}

--- a/controllers/tasks/replication/parameters.go
+++ b/controllers/tasks/replication/parameters.go
@@ -16,23 +16,14 @@ limitations under the License.
 
 package replication
 
-// DemoteVolumeTask stores configuration required to demote volume
-type DemoteVolumeTask struct {
-	// params required for this task
-	CommonRequestParameters
-}
+import (
+	"github.com/kube-storage/volume-replication-operator/pkg/client"
+)
 
-// NewDemoteVolumeTask returns a DemoteVolumeTask object
-func NewDemoteVolumeTask(c CommonRequestParameters) *DemoteVolumeTask {
-	return &DemoteVolumeTask{c}
-}
-
-// Run is used to run DemoteVolume task
-func (d *DemoteVolumeTask) Run() error {
-	_, err := d.Replication.DemoteVolume(
-		d.CommonRequestParameters.VolumeID,
-		d.CommonRequestParameters.Parameters,
-		d.CommonRequestParameters.Secrets,
-	)
-	return err
+// CommonRequestParameters holds the common parameters across replication operations.
+type CommonRequestParameters struct {
+	VolumeID    string
+	Parameters  map[string]string
+	Secrets     map[string]string
+	Replication client.VolumeReplication
 }

--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -86,6 +86,11 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
+	err = validatePrefixedParameters(vrcObj.Spec.Parameters)
+	if err != nil {
+		r.Log.Error(err, "failed to validate prefix parameters", "volumeReplicationClass", instance.Spec.VolumeReplicationClass)
+		return ctrl.Result{}, err
+	}
 	// remove the prefix keys in volume replication class parameters
 	parameters := filterPrefixedParameters(replicationParameterPrefix, vrcObj.Spec.Parameters)
 

--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -86,6 +86,9 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
+	// remove the prefix keys in volume replication class parameters
+	parameters := filterPrefixedParameters(replicationParameterPrefix, vrcObj.Spec.Parameters)
+
 	var volumeHandle string
 	nameSpacedName := types.NamespacedName{Name: instance.Spec.DataSource.Name, Namespace: req.Namespace}
 	switch instance.Spec.DataSource.Kind {

--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -94,6 +94,17 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// remove the prefix keys in volume replication class parameters
 	parameters := filterPrefixedParameters(replicationParameterPrefix, vrcObj.Spec.Parameters)
 
+	// get secret
+	secretName := vrcObj.Spec.Parameters[prefixedReplicationSecretNameKey]
+	secretNamespace := vrcObj.Spec.Parameters[prefixedReplicationSecretNamespaceKey]
+	secret := make(map[string]string)
+	if secretName != "" && secretNamespace != "" {
+		secret, err = r.getSecret(secretName, secretNamespace)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	var volumeHandle string
 	nameSpacedName := types.NamespacedName{Name: instance.Spec.DataSource.Name, Namespace: req.Namespace}
 	switch instance.Spec.DataSource.Kind {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,8 +28,8 @@ import (
 
 // Client holds the GRPC connenction details
 type Client struct {
-	client  *grpc.ClientConn
-	timeout time.Duration
+	Client  *grpc.ClientConn
+	Timeout time.Duration
 }
 
 // Connect to the GRPC client
@@ -44,19 +44,19 @@ func New(address string, timeout time.Duration) (*Client, error) {
 	if err != nil {
 		return c, err
 	}
-	c.client = cc
-	c.timeout = timeout
+	c.Client = cc
+	c.Timeout = timeout
 	return c, nil
 }
 
 // Probe the GRPC client once
 func (c *Client) Probe() error {
-	return rpc.ProbeForever(c.client, c.timeout)
+	return rpc.ProbeForever(c.Client, c.Timeout)
 }
 
 // GetDriverName gets the driver name from the driver
 func (c *Client) GetDriverName() (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer cancel()
-	return rpc.GetDriverName(ctx, c.client)
+	return rpc.GetDriverName(ctx, c.Client)
 }

--- a/pkg/client/fake/replication-client.go
+++ b/pkg/client/fake/replication-client.go
@@ -17,46 +17,44 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
 	replicationlib "github.com/kube-storage/spec/lib/go/replication"
 )
 
 // ReplicationClient to fake replication operations.
 type ReplicationClient struct {
 	// EnableVolumeReplicationMock mocks EnableVolumeReplication RPC call.
-	EnableVolumeReplicationMock func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error)
+	EnableVolumeReplicationMock func(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error)
 	// DisableVolumeReplicationMock mocks DisableVolumeReplication RPC call.
-	DisableVolumeReplicationMock func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error)
+	DisableVolumeReplicationMock func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error)
 	// PromoteVolumeMock mocks PromoteVolume RPC call.
-	PromoteVolumeMock func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error)
+	PromoteVolumeMock func(volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error)
 	// DemoteVolumeMock mocks DemoteVolume RPC call.
-	DemoteVolumeMock func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error)
+	DemoteVolumeMock func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error)
 	// ResyncVolumeMock mocks ResyncVolume RPC call.
-	ResyncVolumeMock func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error)
+	ResyncVolumeMock func(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error)
 }
 
 // EnableVolumeReplication calls EnableVolumeReplicationMock mock function.
-func (rc *ReplicationClient) EnableVolumeReplication(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
-	return rc.EnableVolumeReplicationMock(ctx, volumeID, secrets, parameters)
+func (rc *ReplicationClient) EnableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
+	return rc.EnableVolumeReplicationMock(volumeID, secrets, parameters)
 }
 
 // DisableVolumeReplication calls DisableVolumeReplicationMock mock function.
-func (rc *ReplicationClient) DisableVolumeReplication(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
-	return rc.DisableVolumeReplicationMock(ctx, volumeID, secrets, parameters)
+func (rc *ReplicationClient) DisableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
+	return rc.DisableVolumeReplicationMock(volumeID, secrets, parameters)
 }
 
 // PromoteVolume calls PromoteVolumeMock mock function.
-func (rc *ReplicationClient) PromoteVolume(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
-	return rc.PromoteVolumeMock(ctx, volumeID, secrets, parameters)
+func (rc *ReplicationClient) PromoteVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
+	return rc.PromoteVolumeMock(volumeID, secrets, parameters)
 }
 
 // DemoteVolume calls DemoteVolumeMock mock function.
-func (rc *ReplicationClient) DemoteVolume(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
-	return rc.DemoteVolumeMock(ctx, volumeID, secrets, parameters)
+func (rc *ReplicationClient) DemoteVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
+	return rc.DemoteVolumeMock(volumeID, secrets, parameters)
 }
 
 // ResyncVolume calls ResyncVolumeMock function.
-func (rc *ReplicationClient) ResyncVolume(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
-	return rc.ResyncVolumeMock(ctx, volumeID, secrets, parameters)
+func (rc *ReplicationClient) ResyncVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
+	return rc.ResyncVolumeMock(volumeID, secrets, parameters)
 }

--- a/pkg/client/replication-client.go
+++ b/pkg/client/replication-client.go
@@ -32,17 +32,17 @@ type replicationClient struct {
 // VolumeReplication holds the methods requried for volume replication.
 type VolumeReplication interface {
 	// EnableVolumeReplication RPC call to enable the volume replication.
-	EnableVolumeReplication(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error)
+	EnableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error)
 	// DisableVolumeReplication RPC call to disable the volume replication.
-	DisableVolumeReplication(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error)
+	DisableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error)
 	// PromoteVolume RPC call to promote the volume.
-	PromoteVolume(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.
+	PromoteVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.
 		PromoteVolumeResponse, error)
 	// DemoteVolume RPC call to demote the volume.
-	DemoteVolume(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.
+	DemoteVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.
 		DemoteVolumeResponse, error)
 	// ResyncVolume RPC call to resync the volume.
-	ResyncVolume(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.
+	ResyncVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.
 		ResyncVolumeResponse, error)
 }
 
@@ -53,7 +53,7 @@ func NewReplicationClient(cc *grpc.ClientConn, timeout time.Duration) VolumeRepl
 }
 
 // EnableVolumeReplication RPC call to enable the volume replication.
-func (rc *replicationClient) EnableVolumeReplication(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
+func (rc *replicationClient) EnableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
 	req := &replicationlib.EnableVolumeReplicationRequest{
 		VolumeId:   volumeID,
 		Parameters: parameters,
@@ -67,7 +67,7 @@ func (rc *replicationClient) EnableVolumeReplication(ctx context.Context, volume
 }
 
 // DisableVolumeReplication RPC call to disable the volume replication.
-func (rc *replicationClient) DisableVolumeReplication(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
+func (rc *replicationClient) DisableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
 	req := &replicationlib.DisableVolumeReplicationRequest{
 		VolumeId:   volumeID,
 		Parameters: parameters,
@@ -81,7 +81,7 @@ func (rc *replicationClient) DisableVolumeReplication(ctx context.Context, volum
 }
 
 // PromoteVolume RPC call to promote the volume.
-func (rc *replicationClient) PromoteVolume(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
+func (rc *replicationClient) PromoteVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
 	req := &replicationlib.PromoteVolumeRequest{
 		VolumeId:   volumeID,
 		Parameters: parameters,
@@ -95,7 +95,7 @@ func (rc *replicationClient) PromoteVolume(ctx context.Context, volumeID string,
 }
 
 // DemoteVolume RPC call to demote the volume.
-func (rc *replicationClient) DemoteVolume(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
+func (rc *replicationClient) DemoteVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
 	req := &replicationlib.DemoteVolumeRequest{
 		VolumeId:   volumeID,
 		Parameters: parameters,
@@ -108,7 +108,7 @@ func (rc *replicationClient) DemoteVolume(ctx context.Context, volumeID string, 
 }
 
 // ResyncVolume RPC call to resync the volume.
-func (rc *replicationClient) ResyncVolume(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
+func (rc *replicationClient) ResyncVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
 	req := &replicationlib.ResyncVolumeRequest{
 		VolumeId:   volumeID,
 		Parameters: parameters,

--- a/pkg/client/replication-client_test.go
+++ b/pkg/client/replication-client_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -33,23 +32,23 @@ func TestEnableVolumeReplication(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedEnableReplication := &fake.ReplicationClient{
-		EnableVolumeReplicationMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
+		EnableVolumeReplicationMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
 			return &replicationlib.EnableVolumeReplicationResponse{}, nil
 		},
 	}
 	client = mockedEnableReplication
-	resp, err := client.EnableVolumeReplication(context.Background(), "", nil, nil)
+	resp, err := client.EnableVolumeReplication("", nil, nil)
 	assert.Equal(t, &replicationlib.EnableVolumeReplicationResponse{}, resp)
 	assert.Nil(t, err)
 
 	// return error
 	mockedEnableReplication = &fake.ReplicationClient{
-		EnableVolumeReplicationMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
+		EnableVolumeReplicationMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
 			return nil, errors.New("failed to enable mirroring")
 		},
 	}
 	client = mockedEnableReplication
-	resp, err = client.EnableVolumeReplication(context.Background(), "", nil, nil)
+	resp, err = client.EnableVolumeReplication("", nil, nil)
 	assert.Nil(t, resp)
 	assert.NotNil(t, err)
 }
@@ -58,23 +57,23 @@ func TestDisableVolumeReplication(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedDisableReplication := &fake.ReplicationClient{
-		DisableVolumeReplicationMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
+		DisableVolumeReplicationMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
 			return &replicationlib.DisableVolumeReplicationResponse{}, nil
 		},
 	}
 	client = mockedDisableReplication
-	resp, err := client.DisableVolumeReplication(context.Background(), "", nil, nil)
+	resp, err := client.DisableVolumeReplication("", nil, nil)
 	assert.Equal(t, &replicationlib.DisableVolumeReplicationResponse{}, resp)
 	assert.Nil(t, err)
 
 	// return error
 	mockedDisableReplication = &fake.ReplicationClient{
-		DisableVolumeReplicationMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
+		DisableVolumeReplicationMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
 			return nil, errors.New("failed to disable mirroring")
 		},
 	}
 	client = mockedDisableReplication
-	resp, err = client.DisableVolumeReplication(context.Background(), "", nil, nil)
+	resp, err = client.DisableVolumeReplication("", nil, nil)
 	assert.Nil(t, resp)
 	assert.NotNil(t, err)
 }
@@ -83,23 +82,23 @@ func TestPromoteVolume(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedPromoteVolume := &fake.ReplicationClient{
-		PromoteVolumeMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
+		PromoteVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
 			return &replicationlib.PromoteVolumeResponse{}, nil
 		},
 	}
 	client = mockedPromoteVolume
-	resp, err := client.PromoteVolume(context.Background(), "", nil, nil)
+	resp, err := client.PromoteVolume("", nil, nil)
 	assert.Equal(t, &replicationlib.PromoteVolumeResponse{}, resp)
 	assert.Nil(t, err)
 
 	// return error
 	mockedPromoteVolume = &fake.ReplicationClient{
-		PromoteVolumeMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
+		PromoteVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
 			return nil, errors.New("failed to promote volume")
 		},
 	}
 	client = mockedPromoteVolume
-	resp, err = client.PromoteVolume(context.Background(), "", nil, nil)
+	resp, err = client.PromoteVolume("", nil, nil)
 	assert.Nil(t, resp)
 	assert.NotNil(t, err)
 }
@@ -108,23 +107,23 @@ func TestDemoteVolume(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedDemoteVolume := &fake.ReplicationClient{
-		DemoteVolumeMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
+		DemoteVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
 			return &replicationlib.DemoteVolumeResponse{}, nil
 		},
 	}
 	client = mockedDemoteVolume
-	resp, err := client.DemoteVolume(context.Background(), "", nil, nil)
+	resp, err := client.DemoteVolume("", nil, nil)
 	assert.Equal(t, &replicationlib.DemoteVolumeResponse{}, resp)
 	assert.Nil(t, err)
 
 	// return error
 	mockedDemoteVolume = &fake.ReplicationClient{
-		DemoteVolumeMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
+		DemoteVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
 			return nil, errors.New("failed to demote volume")
 		},
 	}
 	client = mockedDemoteVolume
-	resp, err = client.DemoteVolume(context.Background(), "", nil, nil)
+	resp, err = client.DemoteVolume("", nil, nil)
 	assert.Nil(t, resp)
 	assert.NotNil(t, err)
 }
@@ -133,23 +132,23 @@ func TestResyncVolume(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedResyncVolume := &fake.ReplicationClient{
-		ResyncVolumeMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
+		ResyncVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
 			return &replicationlib.ResyncVolumeResponse{}, nil
 		},
 	}
 	client = mockedResyncVolume
-	resp, err := client.ResyncVolume(context.Background(), "", nil, nil)
+	resp, err := client.ResyncVolume("", nil, nil)
 	assert.Equal(t, &replicationlib.ResyncVolumeResponse{}, resp)
 	assert.Nil(t, err)
 
 	// return error
 	mockedResyncVolume = &fake.ReplicationClient{
-		ResyncVolumeMock: func(ctx context.Context, volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
+		ResyncVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
 			return nil, errors.New("failed to resync volume")
 		},
 	}
 	client = mockedResyncVolume
-	resp, err = client.ResyncVolume(context.Background(), "", nil, nil)
+	resp, err = client.ResyncVolume("", nil, nil)
 	assert.Nil(t, resp)
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Added functionality to get the parameters and secrets from the volume replication class and call the RPC DemoteVolume.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>