### PR TITLE
adds disable task on CR deletion

### DIFF
--- a/controllers/strings.go
+++ b/controllers/strings.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+// Checks whether a string is contained within a slice
+func contains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Removes a given string from a slice and returns the new slice
+func remove(slice []string, s string) (result []string) {
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}

--- a/controllers/tasks/replication/disable.go
+++ b/controllers/tasks/replication/disable.go
@@ -19,15 +19,20 @@ package replication
 // DisableTask stores configuration required to disable volume replication
 type DisableTask struct {
 	// params required for this task
+	CommonRequestParameters
 }
 
 // NewDisableTask returns a DisableTask object
-func NewDisableTask() *DisableTask {
-	return &DisableTask{}
+func NewDisableTask(c CommonRequestParameters) *DisableTask {
+	return &DisableTask{c}
 }
 
 // Run is used to run Disable task
 func (d *DisableTask) Run() error {
-	// perform sub-tasks
-	return nil
+	_, err := d.Replication.DisableVolumeReplication(
+		d.CommonRequestParameters.VolumeID,
+		d.CommonRequestParameters.Secrets,
+		d.CommonRequestParameters.Parameters,
+	)
+	return err
 }


### PR DESCRIPTION
added finalizer for the volumeReplication cr. When the cr is deleted, reconciler will first disable the replication and then remove the finalizer.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>