### PR TITLE
task: Return error and response from the task

### DIFF
--- a/controllers/tasks/replication/demote.go
+++ b/controllers/tasks/replication/demote.go
@@ -28,11 +28,11 @@ func NewDemoteVolumeTask(c CommonRequestParameters) *DemoteVolumeTask {
 }
 
 // Run is used to run DemoteVolume task
-func (d *DemoteVolumeTask) Run() error {
-	_, err := d.Replication.DemoteVolume(
+func (d *DemoteVolumeTask) Run() (interface{}, error) {
+	resp, err := d.Replication.DemoteVolume(
 		d.CommonRequestParameters.VolumeID,
 		d.CommonRequestParameters.Secrets,
 		d.CommonRequestParameters.Parameters,
 	)
-	return err
+	return resp, err
 }

--- a/controllers/tasks/replication/disable.go
+++ b/controllers/tasks/replication/disable.go
@@ -28,11 +28,11 @@ func NewDisableTask(c CommonRequestParameters) *DisableTask {
 }
 
 // Run is used to run Disable task
-func (d *DisableTask) Run() error {
-	_, err := d.Replication.DisableVolumeReplication(
+func (d *DisableTask) Run() (interface{}, error) {
+	resp, err := d.Replication.DisableVolumeReplication(
 		d.CommonRequestParameters.VolumeID,
 		d.CommonRequestParameters.Secrets,
 		d.CommonRequestParameters.Parameters,
 	)
-	return err
+	return resp, err
 }

--- a/controllers/tasks/replication/enable.go
+++ b/controllers/tasks/replication/enable.go
@@ -28,13 +28,13 @@ func NewEnableTask(c CommonRequestParameters) *EnableTask {
 }
 
 // Run is used to run Enable task
-func (e *EnableTask) Run() error {
+func (e *EnableTask) Run() (interface{}, error) {
 	// perform sub-tasks
-	_, err := e.Replication.EnableVolumeReplication(
+	resp, err := e.Replication.EnableVolumeReplication(
 		e.CommonRequestParameters.VolumeID,
 		e.CommonRequestParameters.Secrets,
 		e.CommonRequestParameters.Parameters,
 	)
 
-	return err
+	return resp, err
 }

--- a/controllers/tasks/replication/promote.go
+++ b/controllers/tasks/replication/promote.go
@@ -29,13 +29,13 @@ func NewPromoteVolumeTask(c CommonRequestParameters, force bool) *PromoteVolumeT
 }
 
 // Run is used to run PromoteVolume task
-func (p *PromoteVolumeTask) Run() error {
+func (p *PromoteVolumeTask) Run() (interface{}, error) {
 	// perform sub-tasks
-	_, err := p.Replication.PromoteVolume(
+	resp, err := p.Replication.PromoteVolume(
 		p.CommonRequestParameters.VolumeID,
 		p.Force,
 		p.CommonRequestParameters.Secrets,
 		p.CommonRequestParameters.Parameters,
 	)
-	return err
+	return resp, err
 }

--- a/controllers/tasks/replication/resync.go
+++ b/controllers/tasks/replication/resync.go
@@ -28,11 +28,11 @@ func NewResyncVolumeTask(c CommonRequestParameters) *ResyncVolumeTask {
 }
 
 // Run is used to run ResyncVolume task
-func (r *ResyncVolumeTask) Run() error {
-	_, err := r.Replication.ResyncVolume(
+func (r *ResyncVolumeTask) Run() (interface{}, error) {
+	resp, err := r.Replication.ResyncVolume(
 		r.CommonRequestParameters.VolumeID,
 		r.CommonRequestParameters.Secrets,
 		r.CommonRequestParameters.Parameters,
 	)
-	return err
+	return resp, err
 }

--- a/controllers/tasks/task.go
+++ b/controllers/tasks/task.go
@@ -23,19 +23,34 @@ type TaskSpec struct {
 	KnownErrors []error
 }
 
+// TaskResponse represents the response of each task
+type TaskResponse struct {
+	Name     string
+	Response interface{}
+	Error    error
+}
+
 // Task is a specific task to be done by controller
 type Task interface {
-	Run() error
+	Run() (interface{}, error)
 }
 
 // RunAll executes all the Task in the given list of TaskSpec
-func RunAll(tasks []*TaskSpec) (string, error) {
+func RunAll(tasks []*TaskSpec) []*TaskResponse {
+	taskResp := []*TaskResponse{}
 	for _, task := range tasks {
-		if err := task.Task.Run(); err != nil {
+		resp, err := task.Task.Run()
+		r := &TaskResponse{
+			Name:     task.Name,
+			Response: resp,
+			Error:    err,
+		}
+		taskResp = append(taskResp, r)
+		if err != nil {
 			// if err is in KnownErrors then continue
 			// else return
-			return task.Name, err
+			return taskResp
 		}
 	}
-	return "", nil
+	return taskResp
 }


### PR DESCRIPTION
when we are all the tasks from the controller, the controller has to take few decisions based on the response received from the particular tasks. For example, the controller needs to add the Resync or Secondary volume request to the queue so that it is to wait till the resync is completed and the volume is to be marked as ready to use by application pods.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>