### PR TITLE
update base container image in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
updated base image from `gcr.io/distroless/static:nonroot` to `gcr.io/distroless/static:latest`
which is commonly used in all CSI sidecar image which allows for GRPC communication

using `gcr.io/distroless/static:nonroot` is blocking the GRPC client to connect to the GRPC server.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>