### PR TITLE
add volume-replication to the leader election ID

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 		os.Exit(1)
 	}
 	// unique electionID per operator
-	electionID := cfg.DriverName + "-" + leaderElectionNamespace
+	electionID := cfg.DriverName + "volume-replication-" + leaderElectionNamespace
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                     scheme,


### PR DESCRIPTION
adding volume-replication to the leader election ID to make it unique for volume replication operator.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>