### PR TITLE
VR: Fix error "provided secret is empty"

### DIFF
--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -25,7 +25,7 @@ import (
 )
 
 // getSecret retrives the secrets based on name and namespace input
-func (r *VolumeReplicationReconciler) getSecret(name, namespace string) (map[string]string, error) {
+func (r *VolumeReplicationReconciler) getSecret(name, namespace string) (map[string][]byte, error) {
 	namespacedName := types.NamespacedName{Name: name, Namespace: namespace}
 	secret := &corev1.Secret{}
 	err := r.Client.Get(context.TODO(), namespacedName, secret)
@@ -36,5 +36,5 @@ func (r *VolumeReplicationReconciler) getSecret(name, namespace string) (map[str
 		r.Log.Error(err, "error getting secret", "Secret Name", name, "Secret Namespace", namespace)
 		return nil, err
 	}
-	return secret.StringData, nil
+	return secret.Data, nil
 }

--- a/controllers/tasks/replication/parameters.go
+++ b/controllers/tasks/replication/parameters.go
@@ -24,6 +24,6 @@ import (
 type CommonRequestParameters struct {
 	VolumeID    string
 	Parameters  map[string]string
-	Secrets     map[string]string
+	Secrets     map[string][]byte
 	Replication client.VolumeReplication
 }

--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	replicationlib "github.com/kube-storage/spec/lib/go/replication"
+	replicationlib "github.com/iamniting/spec/lib/go/replication"
 	replicationv1alpha1 "github.com/kube-storage/volume-replication-operator/api/v1alpha1"
 	"github.com/kube-storage/volume-replication-operator/controllers/tasks"
 	"github.com/kube-storage/volume-replication-operator/controllers/tasks/replication"
@@ -112,7 +112,7 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// get secret
 	secretName := vrcObj.Spec.Parameters[prefixedReplicationSecretNameKey]
 	secretNamespace := vrcObj.Spec.Parameters[prefixedReplicationSecretNamespaceKey]
-	secret := make(map[string]string)
+	secret := make(map[string][]byte)
 	if secretName != "" && secretNamespace != "" {
 		secret, err = r.getSecret(secretName, secretNamespace)
 		if err != nil {
@@ -243,7 +243,10 @@ func (r *VolumeReplicationReconciler) SetupWithManager(mgr ctrl.Manager, cfg *co
 }
 
 // markVolumeAsPrimary defines and runs a set of tasks required to mark a volume as primary
-func (r *VolumeReplicationReconciler) markVolumeAsPrimary(volumeReplicationObject *replicationv1alpha1.VolumeReplication, volumeID string, parameters, secrets map[string]string) error {
+func (r *VolumeReplicationReconciler) markVolumeAsPrimary(
+	volumeReplicationObject *replicationv1alpha1.VolumeReplication,
+	volumeID string, parameters map[string]string, secrets map[string][]byte) error {
+
 	c := replication.CommonRequestParameters{
 		VolumeID:    volumeID,
 		Parameters:  parameters,
@@ -306,7 +309,7 @@ func (r *VolumeReplicationReconciler) markVolumeAsPrimary(volumeReplicationObjec
 
 // markVolumeAsSecondary defines and runs a set of tasks required to mark a volume as secondary
 func (r *VolumeReplicationReconciler) markVolumeAsSecondary(volumeReplicationObject *replicationv1alpha1.VolumeReplication,
-	volumeID string, parameters, secrets map[string]string) (bool, error) {
+	volumeID string, parameters map[string]string, secrets map[string][]byte) (bool, error) {
 	c := replication.CommonRequestParameters{
 		VolumeID:    volumeID,
 		Parameters:  parameters,
@@ -348,7 +351,7 @@ func (r *VolumeReplicationReconciler) markVolumeAsSecondary(volumeReplicationObj
 
 // resyncVolume defines and runs a set of tasks required to resync the volume
 func (r *VolumeReplicationReconciler) resyncVolume(volumeReplicationObject *replicationv1alpha1.VolumeReplication,
-	volumeID string, parameters, secrets map[string]string) (bool, error) {
+	volumeID string, parameters map[string]string, secrets map[string][]byte) (bool, error) {
 	c := replication.CommonRequestParameters{
 		VolumeID:    volumeID,
 		Parameters:  parameters,
@@ -397,7 +400,7 @@ func (r *VolumeReplicationReconciler) resyncVolume(volumeReplicationObject *repl
 }
 
 // disableVolumeReplication defines and runs a set of tasks required to disable volume replication
-func (r *VolumeReplicationReconciler) disableVolumeReplication(volumeID string, parameters, secrets map[string]string) error {
+func (r *VolumeReplicationReconciler) disableVolumeReplication(volumeID string, parameters map[string]string, secrets map[string][]byte) error {
 	c := replication.CommonRequestParameters{
 		VolumeID:    volumeID,
 		Parameters:  parameters,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.3.0
-	github.com/kube-storage/spec v0.0.0-20210302071931-ad3b1446aba1
+	github.com/iamniting/spec v0.1.1
 	github.com/kubernetes-csi/csi-lib-utils v0.9.1
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iamniting/spec v0.1.1 h1:T6NdtWusW2UrOlPrZdELVDisKUhoEo5hCAoFF0y4RHo=
+github.com/iamniting/spec v0.1.1/go.mod h1:zRzxQVHrq95HLPzpPvfQh32VvHHZj2V6lA3muffg2jY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
@@ -255,8 +257,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kube-storage/spec v0.0.0-20210302071931-ad3b1446aba1 h1:DTcCQpcvrLEBUmByx/4UmG0Medlv/t4T6WY7GHdeTQc=
-github.com/kube-storage/spec v0.0.0-20210302071931-ad3b1446aba1/go.mod h1:aEM5cuaELIjQPTe4LdyAoR2XvkC5vtd1qz8LgGLf4BQ=
 github.com/kubernetes-csi/csi-lib-utils v0.9.1 h1:sGq6ifVujfMSkfTsMZip44Ttv8SDXvsBlFk9GdYl/b8=
 github.com/kubernetes-csi/csi-lib-utils v0.9.1/go.mod h1:8E2jVUX9j3QgspwHXa6LwyN7IHQDjW9jX3kwoWnSC+M=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/client/fake/replication-client.go
+++ b/pkg/client/fake/replication-client.go
@@ -17,44 +17,44 @@ limitations under the License.
 package fake
 
 import (
-	replicationlib "github.com/kube-storage/spec/lib/go/replication"
+	replicationlib "github.com/iamniting/spec/lib/go/replication"
 )
 
 // ReplicationClient to fake replication operations.
 type ReplicationClient struct {
 	// EnableVolumeReplicationMock mocks EnableVolumeReplication RPC call.
-	EnableVolumeReplicationMock func(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error)
+	EnableVolumeReplicationMock func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error)
 	// DisableVolumeReplicationMock mocks DisableVolumeReplication RPC call.
-	DisableVolumeReplicationMock func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error)
+	DisableVolumeReplicationMock func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error)
 	// PromoteVolumeMock mocks PromoteVolume RPC call.
-	PromoteVolumeMock func(volumeID string, force bool, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error)
+	PromoteVolumeMock func(volumeID string, force bool, secrets map[string][]byte, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error)
 	// DemoteVolumeMock mocks DemoteVolume RPC call.
-	DemoteVolumeMock func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error)
+	DemoteVolumeMock func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error)
 	// ResyncVolumeMock mocks ResyncVolume RPC call.
-	ResyncVolumeMock func(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error)
+	ResyncVolumeMock func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error)
 }
 
 // EnableVolumeReplication calls EnableVolumeReplicationMock mock function.
-func (rc *ReplicationClient) EnableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
+func (rc *ReplicationClient) EnableVolumeReplication(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
 	return rc.EnableVolumeReplicationMock(volumeID, secrets, parameters)
 }
 
 // DisableVolumeReplication calls DisableVolumeReplicationMock mock function.
-func (rc *ReplicationClient) DisableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
+func (rc *ReplicationClient) DisableVolumeReplication(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
 	return rc.DisableVolumeReplicationMock(volumeID, secrets, parameters)
 }
 
 // PromoteVolume calls PromoteVolumeMock mock function.
-func (rc *ReplicationClient) PromoteVolume(volumeID string, force bool, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
+func (rc *ReplicationClient) PromoteVolume(volumeID string, force bool, secrets map[string][]byte, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
 	return rc.PromoteVolumeMock(volumeID, force, secrets, parameters)
 }
 
 // DemoteVolume calls DemoteVolumeMock mock function.
-func (rc *ReplicationClient) DemoteVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
+func (rc *ReplicationClient) DemoteVolume(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
 	return rc.DemoteVolumeMock(volumeID, secrets, parameters)
 }
 
 // ResyncVolume calls ResyncVolumeMock function.
-func (rc *ReplicationClient) ResyncVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
+func (rc *ReplicationClient) ResyncVolume(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
 	return rc.ResyncVolumeMock(volumeID, secrets, parameters)
 }

--- a/pkg/client/replication-client.go
+++ b/pkg/client/replication-client.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"time"
 
-	replicationlib "github.com/kube-storage/spec/lib/go/replication"
+	replicationlib "github.com/iamniting/spec/lib/go/replication"
 	"google.golang.org/grpc"
 )
 
@@ -32,17 +32,17 @@ type replicationClient struct {
 // VolumeReplication holds the methods requried for volume replication.
 type VolumeReplication interface {
 	// EnableVolumeReplication RPC call to enable the volume replication.
-	EnableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error)
+	EnableVolumeReplication(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error)
 	// DisableVolumeReplication RPC call to disable the volume replication.
-	DisableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error)
+	DisableVolumeReplication(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error)
 	// PromoteVolume RPC call to promote the volume.
-	PromoteVolume(volumeID string, force bool, secrets, parameters map[string]string) (*replicationlib.
+	PromoteVolume(volumeID string, force bool, secrets map[string][]byte, parameters map[string]string) (*replicationlib.
 		PromoteVolumeResponse, error)
 	// DemoteVolume RPC call to demote the volume.
-	DemoteVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.
+	DemoteVolume(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.
 		DemoteVolumeResponse, error)
 	// ResyncVolume RPC call to resync the volume.
-	ResyncVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.
+	ResyncVolume(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.
 		ResyncVolumeResponse, error)
 }
 
@@ -53,7 +53,7 @@ func NewReplicationClient(cc *grpc.ClientConn, timeout time.Duration) VolumeRepl
 }
 
 // EnableVolumeReplication RPC call to enable the volume replication.
-func (rc *replicationClient) EnableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
+func (rc *replicationClient) EnableVolumeReplication(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
 	req := &replicationlib.EnableVolumeReplicationRequest{
 		VolumeId:   volumeID,
 		Parameters: parameters,
@@ -67,7 +67,7 @@ func (rc *replicationClient) EnableVolumeReplication(volumeID string, secrets, p
 }
 
 // DisableVolumeReplication RPC call to disable the volume replication.
-func (rc *replicationClient) DisableVolumeReplication(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
+func (rc *replicationClient) DisableVolumeReplication(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
 	req := &replicationlib.DisableVolumeReplicationRequest{
 		VolumeId:   volumeID,
 		Parameters: parameters,
@@ -81,7 +81,7 @@ func (rc *replicationClient) DisableVolumeReplication(volumeID string, secrets, 
 }
 
 // PromoteVolume RPC call to promote the volume.
-func (rc *replicationClient) PromoteVolume(volumeID string, force bool, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
+func (rc *replicationClient) PromoteVolume(volumeID string, force bool, secrets map[string][]byte, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
 	req := &replicationlib.PromoteVolumeRequest{
 		VolumeId:   volumeID,
 		Force:      force,
@@ -96,7 +96,7 @@ func (rc *replicationClient) PromoteVolume(volumeID string, force bool, secrets,
 }
 
 // DemoteVolume RPC call to demote the volume.
-func (rc *replicationClient) DemoteVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
+func (rc *replicationClient) DemoteVolume(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
 	req := &replicationlib.DemoteVolumeRequest{
 		VolumeId:   volumeID,
 		Parameters: parameters,
@@ -109,7 +109,7 @@ func (rc *replicationClient) DemoteVolume(volumeID string, secrets, parameters m
 }
 
 // ResyncVolume RPC call to resync the volume.
-func (rc *replicationClient) ResyncVolume(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
+func (rc *replicationClient) ResyncVolume(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
 	req := &replicationlib.ResyncVolumeRequest{
 		VolumeId:   volumeID,
 		Parameters: parameters,

--- a/pkg/client/replication-client_test.go
+++ b/pkg/client/replication-client_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	replicationlib "github.com/kube-storage/spec/lib/go/replication"
+	replicationlib "github.com/iamniting/spec/lib/go/replication"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 
@@ -32,7 +32,7 @@ func TestEnableVolumeReplication(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedEnableReplication := &fake.ReplicationClient{
-		EnableVolumeReplicationMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
+		EnableVolumeReplicationMock: func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
 			return &replicationlib.EnableVolumeReplicationResponse{}, nil
 		},
 	}
@@ -43,7 +43,7 @@ func TestEnableVolumeReplication(t *testing.T) {
 
 	// return error
 	mockedEnableReplication = &fake.ReplicationClient{
-		EnableVolumeReplicationMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
+		EnableVolumeReplicationMock: func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.EnableVolumeReplicationResponse, error) {
 			return nil, errors.New("failed to enable mirroring")
 		},
 	}
@@ -57,7 +57,7 @@ func TestDisableVolumeReplication(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedDisableReplication := &fake.ReplicationClient{
-		DisableVolumeReplicationMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
+		DisableVolumeReplicationMock: func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
 			return &replicationlib.DisableVolumeReplicationResponse{}, nil
 		},
 	}
@@ -68,7 +68,7 @@ func TestDisableVolumeReplication(t *testing.T) {
 
 	// return error
 	mockedDisableReplication = &fake.ReplicationClient{
-		DisableVolumeReplicationMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
+		DisableVolumeReplicationMock: func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DisableVolumeReplicationResponse, error) {
 			return nil, errors.New("failed to disable mirroring")
 		},
 	}
@@ -82,7 +82,7 @@ func TestPromoteVolume(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedPromoteVolume := &fake.ReplicationClient{
-		PromoteVolumeMock: func(volumeID string, force bool, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
+		PromoteVolumeMock: func(volumeID string, force bool, secrets map[string][]byte, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
 			return &replicationlib.PromoteVolumeResponse{}, nil
 		},
 	}
@@ -94,7 +94,7 @@ func TestPromoteVolume(t *testing.T) {
 
 	// return error
 	mockedPromoteVolume = &fake.ReplicationClient{
-		PromoteVolumeMock: func(volumeID string, force bool, secrets, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
+		PromoteVolumeMock: func(volumeID string, force bool, secrets map[string][]byte, parameters map[string]string) (*replicationlib.PromoteVolumeResponse, error) {
 			return nil, errors.New("failed to promote volume")
 		},
 	}
@@ -108,7 +108,7 @@ func TestDemoteVolume(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedDemoteVolume := &fake.ReplicationClient{
-		DemoteVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
+		DemoteVolumeMock: func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
 			return &replicationlib.DemoteVolumeResponse{}, nil
 		},
 	}
@@ -119,7 +119,7 @@ func TestDemoteVolume(t *testing.T) {
 
 	// return error
 	mockedDemoteVolume = &fake.ReplicationClient{
-		DemoteVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
+		DemoteVolumeMock: func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.DemoteVolumeResponse, error) {
 			return nil, errors.New("failed to demote volume")
 		},
 	}
@@ -133,7 +133,7 @@ func TestResyncVolume(t *testing.T) {
 	var client = NewReplicationClient(&grpc.ClientConn{}, time.Minute)
 	// return success response
 	mockedResyncVolume := &fake.ReplicationClient{
-		ResyncVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
+		ResyncVolumeMock: func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
 			return &replicationlib.ResyncVolumeResponse{}, nil
 		},
 	}
@@ -144,7 +144,7 @@ func TestResyncVolume(t *testing.T) {
 
 	// return error
 	mockedResyncVolume = &fake.ReplicationClient{
-		ResyncVolumeMock: func(volumeID string, secrets, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
+		ResyncVolumeMock: func(volumeID string, secrets map[string][]byte, parameters map[string]string) (*replicationlib.ResyncVolumeResponse, error) {
 			return nil, errors.New("failed to resync volume")
 		},
 	}


### PR DESCRIPTION
getSecret was returning secret.StringData of type `map[string]string`
which does not have a secret key. Secret key is present in the
secret.Data of type `map[string][]byte`. Which require all funcs to
change the secret type from `map[string]string` to `map[string][]byte`.

This will fix
`{"taskName": "Enable volume replication",
"error": "rpc error: code = Internal desc = provided secret is empty"}`

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Depends on https://github.com/kube-storage/spec/pull/17