### PR TITLE
VR: Fix error "provided secret is empty"

### DIFF
--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -36,5 +36,16 @@ func (r *VolumeReplicationReconciler) getSecret(name, namespace string) (map[str
 		r.Log.Error(err, "error getting secret", "Secret Name", name, "Secret Namespace", namespace)
 		return nil, err
 	}
-	return secret.StringData, nil
+	return convertMap(secret.Data), nil
+}
+
+// convertMap converts map[string][]byte to map[string]string
+func convertMap(oldMap map[string][]byte) map[string]string {
+	newMap := make(map[string]string)
+
+	for key, val := range oldMap {
+		newMap[key] = string(val)
+	}
+
+	return newMap
 }


### PR DESCRIPTION
getSecret was returning secret.StringData of type map[string]string
which does not have a secret key. Secret key is present in the
secret.Data of type map[string][]byte.

Fix the getSecret func via returning secret.Data
and converting it to the map[string]string

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>