### PR TITLE
VR: Add more log message in reconcile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bin/*
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# test env
+testbin/


### PR DESCRIPTION
As of now reconcile method have very few logs. Which does not really help in case of failures. Add more logs to address the same.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>