### PR TITLE
VR: Fix markVolumeAsPrimary to return err in case of !isKnownError

### DIFF
--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -304,7 +304,16 @@ func (r *VolumeReplicationReconciler) markVolumeAsPrimary(volumeReplicationObjec
 	resp := tasks.RunAll(promoteVolumeTasks)
 
 	isKnownError := r.hasKnownGRPCError(promoteVolumeTasks, resp)
-	if isKnownError {
+
+	if !isKnownError {
+		for _, re := range resp {
+			if re.Error != nil {
+				r.Log.Error(re.Error, "task failed", "taskName", re.Name)
+				return re.Error
+			}
+		}
+
+	} else {
 		forcePromoteVolumeTasks := []*tasks.TaskSpec{
 			{
 				Name: forcePromoteVolume,


### PR DESCRIPTION
markVolumeAsPrimary was not returning an error when we have an error
which is not known to us. Because of which we were getting nil in
recocile and updating the status of the VR to primary.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>