### PR TITLE
replication: set RequeueAfter to 30 secondary for requeue

### DIFF
--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -263,7 +263,13 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		logger.Info("volume is not ready to use, requeuing for resync")
 
 		_ = r.updateReplicationStatus(instance, logger, getCurrentReplicationState(instance), "volume is degraded")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{
+			Requeue: true,
+			// Setting Requeue time for 30 seconds as the resync can take time
+			// and having default Requeue exponential backoff time can affect
+			// the RTO time.
+			RequeueAfter: time.Duration(time.Second * 30),
+		}, nil
 	}
 
 	var msg string


### PR DESCRIPTION
Setting Requeue time for 30 seconds as the resync can take time and having default Requeue exponential backoff time can affect the RTO time

closes: #120

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>