### PR TITLE
replication: requeue if any error in secondary state

### DIFF
--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -256,6 +256,13 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if replicationErr != nil {
 		logger.Error(replicationErr, "failed to Replicate", "ReplicationState", instance.Spec.ReplicationState)
 		_ = r.updateReplicationStatus(instance, logger, getCurrentReplicationState(instance), replicationErr.Error())
+		if instance.Status.State == replicationv1alpha1.SecondaryState {
+			return ctrl.Result{
+				Requeue: true,
+				// in case of any error during secondary state, requeue for every 15 seconds.
+				RequeueAfter: time.Duration(time.Second * 15),
+			}, nil
+		}
 		return ctrl.Result{}, replicationErr
 	}
 


### PR DESCRIPTION
if the resync failed (marking the image as secondary)
failed, requeue the request for 15 seconds as this can
also increases the recovery time.

address https://github.com/csi-addons/volume-replication-operator/pull/123#discussion_r735589234

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>