### PR TITLE
Ensure only one VR per PVC

### DIFF
--- a/api/v1alpha1/volumereplication_types.go
+++ b/api/v1alpha1/volumereplication_types.go
@@ -36,6 +36,10 @@ const (
 	Resync ReplicationState = "resync"
 )
 
+const (
+	VolumeReplicationNameAnnotation = "replication.storage.openshift.io/volume-replication-name"
+)
+
 // State captures the latest state of the replication operation.
 type State string
 

--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -188,6 +188,14 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 			return reconcile.Result{}, err
 		}
+
+		err = r.annotatePVCWithOwner(ctx, logger, req.Name, pvc)
+		if err != nil {
+			logger.Error(err, "Failed to annotate PVC owner")
+
+			return ctrl.Result{}, err
+		}
+
 		if err = r.addFinalizerToPVC(logger, pvc); err != nil {
 			logger.Error(err, "Failed to add PersistentVolumeClaim finalizer")
 
@@ -201,6 +209,13 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 				return ctrl.Result{}, err
 			}
+
+			if err = r.removeOwnerFromPVCAnnotation(ctx, logger, pvc); err != nil {
+				logger.Error(err, "Failed to remove VolumeReplication annotation")
+
+				return reconcile.Result{}, err
+			}
+
 			if err = r.removeFinalizerFromPVC(logger, pvc); err != nil {
 				logger.Error(err, "Failed to remove PersistentVolumeClaim finalizer")
 


### PR DESCRIPTION
VolumeReplication should ensure only one VR per PVC; otherwise, it can lead to orchestrating the PVC based on multiple VRs to an inconsistent state. With this Patch, only one VR will operate on a single PVC.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>