### PR TITLE
Fix bug 2207632: infinite loop due to adding VR finalizer during PVC deletion

### DIFF
--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -188,10 +188,12 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 			return reconcile.Result{}, err
 		}
-		if err = r.addFinalizerToPVC(logger, pvc); err != nil {
-			logger.Error(err, "Failed to add PersistentVolumeClaim finalizer")
+		if pvc.GetDeletionTimestamp().IsZero() {
+			if err = r.addFinalizerToPVC(logger, pvc); err != nil {
+				logger.Error(err, "Failed to add PersistentVolumeClaim finalizer")
 
-			return reconcile.Result{}, err
+				return reconcile.Result{}, err
+			}
 		}
 	} else {
 		if contains(instance.GetFinalizers(), volumeReplicationFinalizer) {


### PR DESCRIPTION
Resolve issue with VR falling into an infinite loop when attempting to add the finalizer "replication.storage.openshift.io/pvc-protection" during PVC deletion.

Fixing bug [2207632](https://bugzilla.redhat.com/show_bug.cgi?id=2207632)

Relevant gchat conversion is found [here](https://mail.google.com/chat/u/0/#chat/space/AAAAqWkMm2s/-h4y2DRqCcM): 